### PR TITLE
bump versions

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -85,7 +85,7 @@
         "properties": {
           "Discord": "https://discord.gg/GWxWtcwA2C",
           "Github": "https://github.com/homchom/recode",
-          "Version": "1.19.2"
+          "Version": "1.20.1"
         }
       }, {
         "name": "LessUtilities",
@@ -100,7 +100,7 @@
         "properties": {
           "Discord": "https://discord.gg/pEZYShEj",
           "Github": "https://github.com/DFOnline/DFScript",
-          "Version": "1.20"
+          "Version": "1.20.1"
         }
       }, {
         "name": "CodeClient",


### PR DESCRIPTION
LessUtilities has `1.20.x` in the mod json but doesnt state that it works with 1.20.1 anywhere, similarly to codeclient, which uses `~1.20`